### PR TITLE
feature: delegate to_a, to_ary to call

### DIFF
--- a/lib/findit/collections.rb
+++ b/lib/findit/collections.rb
@@ -40,7 +40,7 @@ module Findit
     extend ActiveSupport::Concern
 
     included do
-      delegate :each, :[], :size, :empty?, to: :call
+      delegate :each, :[], :size, :empty?, :to_ary, :to_a, to: :call
     end
 
     module ClassMethods


### PR DESCRIPTION
Теперь можно делать так 

```
@posts = PostFinder.new(..)
render 'post', collection: @posts
```

тк - https://github.com/rails/rails/blob/master/actionview/lib/action_view/renderer/partial_renderer.rb#L406
rails - 3.1 - https://github.com/rails/rails/blob/3-1-stable/actionpack/lib/action_view/renderer/partial_renderer.rb#L301
Для других версий тоже верно, если надо могу ссылки привести.
