### PR TITLE
fix: expire_in -> expires_in typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ class PostsController < ApplicationController
 end
 
 #/app/views/posts/index.html.erb
-<% cache(@posts, expire_in: 30.minutes) do %>
+<% cache(@posts, expires_in: 30.minutes) do %>
    <%=render 'post', collection: @posts, as: :post%> # it will automaticly iterate over finder results by each method
 ```
 
@@ -197,7 +197,7 @@ class PostsController < ApplicationController
 end
 
 # app/views/posts/index.html.erb
-<% cache(@posts, expire_in: 30.minutes) do %>
+<% cache(@posts, expires_in: 30.minutes) do %>
   <%= render 'post', collection: @posts, as: :post %>
   <%= will_paginate @posts %>
 ```
@@ -232,7 +232,7 @@ end
 ### Cache
 
 Extends finder with cache possibility. Every call of `call` method will be cached in `Rails.cache`.
-Method `cache options` allows you to add custom options like `expire_in` or `tags` to `Rails.cache.fetch`.
+Method `cache options` allows you to add custom options like `expires_in` or `tags` to `Rails.cache.fetch`.
 If you want to disable cache dependent of initialization arguments, you can use `cache?` DSL method.
 
 All in one Example:
@@ -247,7 +247,7 @@ class CachedPostsFinder
   end
 
   cache_options do
-    {expire_in: 15.minutes} # This will be directly passed to Rails.cache.fetch
+    {expires_in: 15.minutes} # This will be directly passed to Rails.cache.fetch
   end
 
   def initialize(user)

--- a/lib/findit/cache.rb
+++ b/lib/findit/cache.rb
@@ -14,7 +14,7 @@
 #    end
 #
 #    cache_options do
-#      {expire_in: 15.minutes}
+#      {expires_in: 15.minutes}
 #    end
 #
 #    private

--- a/lib/findit/collections.rb
+++ b/lib/findit/collections.rb
@@ -31,7 +31,7 @@
 #  end
 #
 #  #/app/views/posts/index.html.erb
-#  <% cache(@posts, tags: @posts.cache_tags, expire_in: @posts.expire_in) do %>
+#  <% cache(@posts, tags: @posts.cache_tags, expires_in: @posts.expires_in) do %>
 #    <%= render 'post' colection: @posts, as: :post%>
 #
 module Findit

--- a/lib/findit/single.rb
+++ b/lib/findit/single.rb
@@ -29,7 +29,7 @@
 #  end
 #
 #  #/app/views/posts/show.html.erb
-#  <% cache(@post, expire_in: 15.minutes) do %>
+#  <% cache(@post, expires_in: 15.minutes) do %>
 #    <%= render 'post', post: @post.load%>
 #
 module Findit

--- a/spec/internal/app/finders/cached_post_finder.rb
+++ b/spec/internal/app/finders/cached_post_finder.rb
@@ -7,7 +7,7 @@ class CachedPostFinder
   end
 
   cache_options do
-    {expire_in: 15.minutes}
+    {expires_in: 15.minutes}
   end
 
   def initialize(user, options = {})


### PR DESCRIPTION
Из поисков по коду как я понял expires_in это верный вариант

https://github.com/sorentwo/readthis/blob/v2.0.2/lib/readthis/cache.rb#L395